### PR TITLE
🔧  Fixing the provisioned test server that will not crash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,7 @@ cd /vagrant
 # Install dependencies with Pipenv
 pipenv sync --dev
 
-# run our app. Nohup and "&" are used to let the setup script finish
-# while our app stays up. The app logs will be collected in nohup.out
-nohup pipenv run python manage.py runserver 0.0.0.0:8000 &
+# run our app. setsit, the parentheses and "&" are used to perform a "double
+# fork" so that out app stays up after the setup script finishes.
+# The app logs are redirected to the `runserver.log` file.
+(setsid pipenv run python manage.py runserver 0.0.0.0:8000 > runserver.log 2>&1 &)


### PR DESCRIPTION
The way we launched the Django dev server in the provision script had
caused it to crash every time we change the code.
With the new command that updated on setup.sh file, it reloads the web application as we will edit the code

Close #31 

Signed-off-by: Erez Cohen <erez6356458@gmail.com>