### PR TITLE
Adding .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Mac OS
+**/.DS_Store
+
 # IDEA
 .idea
 


### PR DESCRIPTION
.DS_Store is MacOS file thats stores custom attributes of its containing folder https://en.wikipedia.org/wiki/.DS_Store.
Such file should not be committed 


closes #34 

Signed-off-by: Jenia Sakirko <jenia.sakirko@gmail.com>