### PR TITLE
rename pytest.imi to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = Hotails.settings
 django_debug_mode = true
-python_files = tests.py test_*.py *_tests.py
+python_files = tests.py test_*.py *_tests.py *_test.py


### PR DESCRIPTION
pytest configuration was named **imi** instead of **ini**

closes #43 

Signed-off-by: Jenia Sakirko <jenia.sakirko@gmail.com>